### PR TITLE
Fix compile on clamav 1.0

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,13 +8,13 @@ use clamav_sys::cl_error_t;
 /// An error indicating a clam failure.
 #[derive(Clone, PartialEq, Eq)]
 pub struct ClamError {
-    code: i32,
+    code: cl_error_t,
 }
 
 impl ClamError {
     pub fn new(native_err: cl_error_t) -> Self {
         ClamError {
-            code: native_err as i32,
+            code: native_err,
         }
     }
 
@@ -30,13 +30,13 @@ impl ClamError {
     }
 
     pub fn code(&self) -> i32 {
-        self.code
+        self.code as i32
     }
 }
 
 impl fmt::Display for ClamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "cl_error {}: {}", self.code, self.string_error())
+        write!(f, "cl_error {}: {}", self.code as i32, self.string_error())
     }
 }
 


### PR DESCRIPTION
Fixes this error:
```
error[E0308]: mismatched types
   --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/clamav-rs-0.5.5/src/error.rs:23:47
    |
23  |             let ptr = clamav_sys::cl_strerror(self.code);
    |                       ----------------------- ^^^^^^^^^ expected enum `cl_error_t`, found `i32`
    |                       |
    |                       arguments to this function are incorrect
    |
note: function defined here
   --> /home/user/repos/kpcyrd/libredefender/target/debug/build/clamav-sys-32481c721146e509/out/bindings.rs:305:12
    |
305 |     pub fn cl_strerror(clerror: cl_error_t) -> *const ::std::os::raw::c_char;
    |            ^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
```